### PR TITLE
Update README.md / utilize customfeeds.list

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ wget -O /etc/apk/keys/glass-apk.rsa.pub \
   https://raw.githubusercontent.com/rchen14b/luci-theme-glass/main/root/etc/apk/keys/glass-apk.rsa.pub
 
 # Add feed and install
-echo "https://rchen14b.github.io/luci-theme-glass/apk/packages.adb" > /etc/apk/repositories.d/glass.list
+echo "https://rchen14b.github.io/luci-theme-glass/apk/packages.adb" > /etc/apk/repositories.d/customfeeds.list
 apk update
 apk add luci-theme-glass
 ```


### PR DESCRIPTION
Improve the ROM’s updateability and configuration recovery by using the default file `/etc/apk/repositories.d/customfeeds.list` instead of `glass.list`. This ensures that the theme repository is backed up via a standard configuration backup, without the need to specify additional custom backup paths in the configuration.

Perhaps something similar can also be achieved with the file `/etc/apk/keys/glass-apk.rsa.pub`.