### PR TITLE
i18n: complete translations for 8 languages (de, fr, ja, ko, pt-br, ru, zh_Hans, zh_Hant)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,13 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Glass - Apple-inspired glassmorphism theme for LuCI
-LUCI_DEPENDS:=
+LUCI_DESCRIPTION:=A modern glassmorphism LuCI theme inspired by Apple design.
+LUCI_PKGARCH:=all
 PKG_VERSION:=$(shell cat $(CURDIR)/ucode/template/themes/glass/version | tr -d '[:space:]')
 PKG_RELEASE:=1
 
 # Disable CSS minification (backdrop-filter can break with csstidy)
-CONFIG_LUCI_CSSTIDY:=
+LUCI_MINIFY_CSS:=0
 
 include $(TOPDIR)/feeds/luci/luci.mk
 

--- a/po/de/glass.po
+++ b/po/de/glass.po
@@ -6,204 +6,206 @@ msgstr ""
 
 #: htdocs/luci-static/resources/view/system/glass.js:52
 msgid "Accent Colors"
-msgstr ""
+msgstr "Akzentfarben"
 
 #: htdocs/luci-static/resources/view/system/glass.js:72
 msgid "Accent color used for active elements, links, and buttons in dark mode."
-msgstr ""
+msgstr "Akzentfarbe für aktive Elemente, Links und Schaltflächen im Dunkelmodus."
 
 #: htdocs/luci-static/resources/view/system/glass.js:56
 msgid ""
 "Accent color used for active elements, links, and buttons in light mode."
-msgstr ""
+msgstr "Akzentfarbe für aktive Elemente, Links und Schaltflächen im Hellmodus."
 
 #: htdocs/luci-static/resources/view/system/glass.js:128
 msgid "Active"
-msgstr ""
+msgstr "Aktiv"
 
 #: htdocs/luci-static/resources/view/system/glass.js:33
 msgid "Auto (follow system)"
-msgstr ""
+msgstr "Automatisch (System folgen)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:108
 msgid "Backdrop blur radius for glass panels in dark mode."
-msgstr ""
+msgstr "Hintergrundweichzeichner-Radius für Glasfelder im Dunkelmodus."
 
 #: htdocs/luci-static/resources/view/system/glass.js:92
 msgid ""
 "Backdrop blur radius for glass panels. Higher values create a more frosted "
 "appearance."
-msgstr ""
+msgstr "Hintergrundweichzeichner-Radius für Glasfelder. Höhere Werte erzeugen einen stärkeren Mattglas-Effekt."
 
 #: htdocs/luci-static/resources/view/system/glass.js:120
 msgid "Background"
-msgstr ""
+msgstr "Hintergrund"
 
 #: htdocs/luci-static/resources/view/system/glass.js:98
 msgid ""
 "Background opacity of glass panels (0 = fully transparent, 1 = fully opaque)."
-msgstr ""
+msgstr "Hintergrunddeckkraft der Glasfelder (0 = vollständig transparent, 1 = vollständig undurchsichtig)."
 
 #: htdocs/luci-static/resources/view/system/glass.js:114
 msgid ""
 "Background opacity of glass panels in dark mode (0 = fully transparent, 1 = "
 "fully opaque)."
-msgstr ""
+msgstr "Hintergrunddeckkraft der Glasfelder im Dunkelmodus (0 = vollständig transparent, 1 = vollständig undurchsichtig)."
 
 #: htdocs/luci-static/resources/view/system/glass.js:43
 msgid "Base font size"
-msgstr ""
+msgstr "Basisschriftgröße"
 
 #: htdocs/luci-static/resources/view/system/glass.js:91
 #: htdocs/luci-static/resources/view/system/glass.js:107
 msgid "Blur intensity (px)"
-msgstr ""
+msgstr "Weichzeichnerstärke (px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:25
 msgid ""
 "Configure the appearance of the Glass theme. Changes take effect after "
 "saving and refreshing the page."
-msgstr ""
+msgstr "Erscheinungsbild des Glass-Themes konfigurieren. Änderungen werden nach dem Speichern und Aktualisieren wirksam."
 
 #: htdocs/luci-static/resources/view/system/glass.js:32
 msgid ""
 "Controls the overall appearance. \"Normal\" follows the system preference."
-msgstr ""
+msgstr "Steuert das allgemeine Erscheinungsbild. »Auto« folgt den Systemeinstellungen."
 
 #: htdocs/luci-static/resources/view/system/glass.js:123
 msgid "Current background"
-msgstr ""
+msgstr "Aktueller Hintergrund"
 
 #: htdocs/luci-static/resources/view/system/glass.js:35
 msgid "Dark"
-msgstr ""
+msgstr "Dunkel"
 
 #: htdocs/luci-static/resources/view/system/glass.js:48
 msgid "Extra Large (18px)"
-msgstr ""
+msgstr "Sehr groß (18px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:28
 msgid "General"
-msgstr ""
+msgstr "Allgemein"
 
 #: htdocs/luci-static/resources/view/system/glass.js:104
 msgid "Glass Effects — Dark Mode"
-msgstr ""
+msgstr "Glaseffekte — Dunkelmodus"
 
 #: htdocs/luci-static/resources/view/system/glass.js:88
 msgid "Glass Effects — Light Mode"
-msgstr ""
+msgstr "Glaseffekte — Hellmodus"
 
 #: htdocs/luci-static/resources/view/system/glass.js:24
 msgid "Glass Theme"
-msgstr ""
+msgstr "Glass-Theme"
 
 #: root/usr/share/luci/menu.d/luci-theme-glass.json:3
 msgid "Glass Theme Config"
-msgstr ""
+msgstr "Glass-Theme-Konfiguration"
 
 #: ucode/template/themes/glass/header.ut:204
 msgid "Go to password configuration..."
-msgstr ""
+msgstr "Zur Passwortkonfiguration..."
 
 #: root/usr/share/rpcd/acl.d/luci-theme-glass.json:3
 msgid "Grant access for luci-theme-glass"
-msgstr ""
+msgstr "Zugriff für luci-theme-glass gewähren"
 
 #: htdocs/luci-static/resources/view/system/glass.js:38
 msgid "Header status bar"
-msgstr ""
+msgstr "Statusleiste im Header"
 
 #: ucode/template/themes/glass/sysauth.ut:111
 msgid "Invalid username and/or password! Please try again."
-msgstr ""
+msgstr "Ungültiger Benutzername oder falsches Passwort! Bitte erneut versuchen."
 
 #: ucode/template/themes/glass/header.ut:211
 msgid "JavaScript required!"
-msgstr ""
+msgstr "JavaScript erforderlich!"
 
 #: htdocs/luci-static/resources/view/system/glass.js:47
 msgid "Large (16px)"
-msgstr ""
+msgstr "Groß (16px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:34
 msgid "Light"
-msgstr ""
+msgstr "Hell"
 
 #: ucode/template/themes/glass/sysauth.ut:129
 msgid "Log in"
-msgstr ""
+msgstr "Anmelden"
 
 #: ucode/template/themes/glass/sysauth.ut:51
 msgid "Login"
-msgstr ""
+msgstr "Anmeldung"
 
 #: htdocs/luci-static/resources/view/system/glass.js:131
 msgid ""
 "No background set. Upload an image or video named \"bg\" (e.g. bg.jpg, "
 "bg.png, bg.mp4) to /www/luci-static/glass/background/ via SCP."
 msgstr ""
+"Kein Hintergrund gesetzt. Laden Sie ein Bild oder Video namens \"bg\" (z. B. bg.jpg, "
+"bg.png, bg.mp4) über SCP nach /www/luci-static/glass/background/ hoch."
 
 #: ucode/template/themes/glass/header.ut:201
 msgid "No password set!"
-msgstr ""
+msgstr "Kein Passwort gesetzt!"
 
 #: htdocs/luci-static/resources/view/system/glass.js:46
 msgid "Normal (14px)"
-msgstr ""
+msgstr "Normal (14px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:97
 #: htdocs/luci-static/resources/view/system/glass.js:113
 msgid "Panel transparency"
-msgstr ""
+msgstr "Paneltransparenz"
 
 #: ucode/template/themes/glass/sysauth.ut:124
 msgid "Password"
-msgstr ""
+msgstr "Passwort"
 
 #: htdocs/luci-static/resources/view/system/glass.js:71
 msgid "Primary color (dark mode)"
-msgstr ""
+msgstr "Primärfarbe (Dunkelmodus)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:55
 msgid "Primary color (light mode)"
-msgstr ""
+msgstr "Primärfarbe (Hellmodus)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:44
 msgid ""
 "Scales all text in the theme. Larger values improve readability on high-DPI "
 "displays."
-msgstr ""
+msgstr "Skaliert den gesamten Text des Themes. Höhere Werte verbessern die Lesbarkeit auf HiDPI-Displays."
 
 #: htdocs/luci-static/resources/view/system/glass.js:39
 msgid ""
 "Show live system stats (CPU, RAM, network, uptime) in the header. Disable to "
 "reduce resource usage on low-end devices."
-msgstr ""
+msgstr "Live-Systemstatistiken (CPU, RAM, Netzwerk, Betriebszeit) im Header anzeigen. Deaktivieren, um die Ressourcennutzung auf schwachen Geräten zu reduzieren."
 
 #: ucode/template/themes/glass/sysauth.ut:106
 msgid "Sign in to continue"
-msgstr "Zum Fortfahren anmelden"
+msgstr "Anmelden, um fortzufahren"
 
 #: htdocs/luci-static/resources/view/system/glass.js:45
 msgid "Small (13px)"
-msgstr ""
+msgstr "Klein (13px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:31
 msgid "Theme mode"
-msgstr ""
+msgstr "Theme-Modus"
 
 #: ucode/template/themes/glass/header.ut:202
 msgid ""
 "There is no password set on this router. Please configure a root password to "
 "protect the web interface."
-msgstr ""
+msgstr "Auf diesem Router ist kein Passwort gesetzt. Bitte legen Sie ein Root-Passwort fest, um die Weboberfläche zu schützen."
 
 #: ucode/template/themes/glass/sysauth.ut:117
 msgid "Username"
-msgstr ""
+msgstr "Benutzername"
 
 #: ucode/template/themes/glass/header.ut:212
 msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
-msgstr ""
+msgstr "JavaScript muss im Browser aktiviert sein, sonst funktioniert LuCI nicht ordnungsgemäß."

--- a/po/fr/glass.po
+++ b/po/fr/glass.po
@@ -6,180 +6,182 @@ msgstr ""
 
 #: htdocs/luci-static/resources/view/system/glass.js:52
 msgid "Accent Colors"
-msgstr ""
+msgstr "Couleurs d'accentuation"
 
 #: htdocs/luci-static/resources/view/system/glass.js:72
 msgid "Accent color used for active elements, links, and buttons in dark mode."
-msgstr ""
+msgstr "Couleur d'accentuation pour les éléments actifs, liens et boutons en mode sombre."
 
 #: htdocs/luci-static/resources/view/system/glass.js:56
 msgid ""
 "Accent color used for active elements, links, and buttons in light mode."
-msgstr ""
+msgstr "Couleur d'accentuation pour les éléments actifs, liens et boutons en mode clair."
 
 #: htdocs/luci-static/resources/view/system/glass.js:128
 msgid "Active"
-msgstr ""
+msgstr "Actif"
 
 #: htdocs/luci-static/resources/view/system/glass.js:33
 msgid "Auto (follow system)"
-msgstr ""
+msgstr "Auto (suivre le système)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:108
 msgid "Backdrop blur radius for glass panels in dark mode."
-msgstr ""
+msgstr "Rayon de flou d'arrière-plan pour les panneaux en mode sombre."
 
 #: htdocs/luci-static/resources/view/system/glass.js:92
 msgid ""
 "Backdrop blur radius for glass panels. Higher values create a more frosted "
 "appearance."
-msgstr ""
+msgstr "Rayon de flou d'arrière-plan pour les panneaux en verre. Des valeurs plus élevées créent un effet dépoli plus prononcé."
 
 #: htdocs/luci-static/resources/view/system/glass.js:120
 msgid "Background"
-msgstr ""
+msgstr "Arrière-plan"
 
 #: htdocs/luci-static/resources/view/system/glass.js:98
 msgid ""
 "Background opacity of glass panels (0 = fully transparent, 1 = fully opaque)."
-msgstr ""
+msgstr "Opacité d'arrière-plan des panneaux (0 = totalement transparent, 1 = totalement opaque)."
 
 #: htdocs/luci-static/resources/view/system/glass.js:114
 msgid ""
 "Background opacity of glass panels in dark mode (0 = fully transparent, 1 = "
 "fully opaque)."
-msgstr ""
+msgstr "Opacité d'arrière-plan des panneaux en mode sombre (0 = totalement transparent, 1 = totalement opaque)."
 
 #: htdocs/luci-static/resources/view/system/glass.js:43
 msgid "Base font size"
-msgstr ""
+msgstr "Taille de police de base"
 
 #: htdocs/luci-static/resources/view/system/glass.js:91
 #: htdocs/luci-static/resources/view/system/glass.js:107
 msgid "Blur intensity (px)"
-msgstr ""
+msgstr "Intensité du flou (px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:25
 msgid ""
 "Configure the appearance of the Glass theme. Changes take effect after "
 "saving and refreshing the page."
-msgstr ""
+msgstr "Configurer l'apparence du thème Glass. Les modifications prennent effet après sauvegarde et actualisation."
 
 #: htdocs/luci-static/resources/view/system/glass.js:32
 msgid ""
 "Controls the overall appearance. \"Normal\" follows the system preference."
-msgstr ""
+msgstr "Contrôle l'apparence générale. « Auto » suit les préférences du système."
 
 #: htdocs/luci-static/resources/view/system/glass.js:123
 msgid "Current background"
-msgstr ""
+msgstr "Arrière-plan actuel"
 
 #: htdocs/luci-static/resources/view/system/glass.js:35
 msgid "Dark"
-msgstr ""
+msgstr "Sombre"
 
 #: htdocs/luci-static/resources/view/system/glass.js:48
 msgid "Extra Large (18px)"
-msgstr ""
+msgstr "Très grand (18px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:28
 msgid "General"
-msgstr ""
+msgstr "Général"
 
 #: htdocs/luci-static/resources/view/system/glass.js:104
 msgid "Glass Effects — Dark Mode"
-msgstr ""
+msgstr "Effets verre — Mode sombre"
 
 #: htdocs/luci-static/resources/view/system/glass.js:88
 msgid "Glass Effects — Light Mode"
-msgstr ""
+msgstr "Effets verre — Mode clair"
 
 #: htdocs/luci-static/resources/view/system/glass.js:24
 msgid "Glass Theme"
-msgstr ""
+msgstr "Thème Glass"
 
 #: root/usr/share/luci/menu.d/luci-theme-glass.json:3
 msgid "Glass Theme Config"
-msgstr ""
+msgstr "Configuration du thème Glass"
 
 #: ucode/template/themes/glass/header.ut:204
 msgid "Go to password configuration..."
-msgstr ""
+msgstr "Aller à la configuration du mot de passe..."
 
 #: root/usr/share/rpcd/acl.d/luci-theme-glass.json:3
 msgid "Grant access for luci-theme-glass"
-msgstr ""
+msgstr "Accorder l'accès à luci-theme-glass"
 
 #: htdocs/luci-static/resources/view/system/glass.js:38
 msgid "Header status bar"
-msgstr ""
+msgstr "Barre d'état de l'en-tête"
 
 #: ucode/template/themes/glass/sysauth.ut:111
 msgid "Invalid username and/or password! Please try again."
-msgstr ""
+msgstr "Nom d'utilisateur et/ou mot de passe incorrect(s) ! Veuillez réessayer."
 
 #: ucode/template/themes/glass/header.ut:211
 msgid "JavaScript required!"
-msgstr ""
+msgstr "JavaScript requis !"
 
 #: htdocs/luci-static/resources/view/system/glass.js:47
 msgid "Large (16px)"
-msgstr ""
+msgstr "Grand (16px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:34
 msgid "Light"
-msgstr ""
+msgstr "Clair"
 
 #: ucode/template/themes/glass/sysauth.ut:129
 msgid "Log in"
-msgstr ""
+msgstr "Se connecter"
 
 #: ucode/template/themes/glass/sysauth.ut:51
 msgid "Login"
-msgstr ""
+msgstr "Connexion"
 
 #: htdocs/luci-static/resources/view/system/glass.js:131
 msgid ""
 "No background set. Upload an image or video named \"bg\" (e.g. bg.jpg, "
 "bg.png, bg.mp4) to /www/luci-static/glass/background/ via SCP."
 msgstr ""
+"Aucun arrière-plan défini. Téléversez une image ou vidéo nommée \"bg\" (ex. bg.jpg, "
+"bg.png, bg.mp4) dans /www/luci-static/glass/background/ via SCP."
 
 #: ucode/template/themes/glass/header.ut:201
 msgid "No password set!"
-msgstr ""
+msgstr "Aucun mot de passe défini !"
 
 #: htdocs/luci-static/resources/view/system/glass.js:46
 msgid "Normal (14px)"
-msgstr ""
+msgstr "Normal (14px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:97
 #: htdocs/luci-static/resources/view/system/glass.js:113
 msgid "Panel transparency"
-msgstr ""
+msgstr "Transparence des panneaux"
 
 #: ucode/template/themes/glass/sysauth.ut:124
 msgid "Password"
-msgstr ""
+msgstr "Mot de passe"
 
 #: htdocs/luci-static/resources/view/system/glass.js:71
 msgid "Primary color (dark mode)"
-msgstr ""
+msgstr "Couleur principale (mode sombre)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:55
 msgid "Primary color (light mode)"
-msgstr ""
+msgstr "Couleur principale (mode clair)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:44
 msgid ""
 "Scales all text in the theme. Larger values improve readability on high-DPI "
 "displays."
-msgstr ""
+msgstr "Redimensionne tout le texte du thème. Des valeurs plus élevées améliorent la lisibilité sur les écrans haute résolution."
 
 #: htdocs/luci-static/resources/view/system/glass.js:39
 msgid ""
 "Show live system stats (CPU, RAM, network, uptime) in the header. Disable to "
 "reduce resource usage on low-end devices."
-msgstr ""
+msgstr "Affiche les statistiques système en temps réel (CPU, RAM, réseau, uptime) dans l'en-tête. Désactiver sur les appareils bas de gamme."
 
 #: ucode/template/themes/glass/sysauth.ut:106
 msgid "Sign in to continue"
@@ -187,23 +189,23 @@ msgstr "Connectez-vous pour continuer"
 
 #: htdocs/luci-static/resources/view/system/glass.js:45
 msgid "Small (13px)"
-msgstr ""
+msgstr "Petit (13px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:31
 msgid "Theme mode"
-msgstr ""
+msgstr "Mode du thème"
 
 #: ucode/template/themes/glass/header.ut:202
 msgid ""
 "There is no password set on this router. Please configure a root password to "
 "protect the web interface."
-msgstr ""
+msgstr "Aucun mot de passe n'est défini sur ce routeur. Veuillez configurer un mot de passe root pour protéger l'interface web."
 
 #: ucode/template/themes/glass/sysauth.ut:117
 msgid "Username"
-msgstr ""
+msgstr "Nom d'utilisateur"
 
 #: ucode/template/themes/glass/header.ut:212
 msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
-msgstr ""
+msgstr "Vous devez activer JavaScript dans votre navigateur, sinon LuCI ne fonctionnera pas correctement."

--- a/po/ja/glass.po
+++ b/po/ja/glass.po
@@ -6,180 +6,182 @@ msgstr ""
 
 #: htdocs/luci-static/resources/view/system/glass.js:52
 msgid "Accent Colors"
-msgstr ""
+msgstr "アクセントカラー"
 
 #: htdocs/luci-static/resources/view/system/glass.js:72
 msgid "Accent color used for active elements, links, and buttons in dark mode."
-msgstr ""
+msgstr "ダークモードでのアクティブ要素・リンク・ボタンのアクセントカラー。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:56
 msgid ""
 "Accent color used for active elements, links, and buttons in light mode."
-msgstr ""
+msgstr "ライトモードでのアクティブ要素・リンク・ボタンのアクセントカラー。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:128
 msgid "Active"
-msgstr ""
+msgstr "設定済み"
 
 #: htdocs/luci-static/resources/view/system/glass.js:33
 msgid "Auto (follow system)"
-msgstr ""
+msgstr "自動（システムに従う）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:108
 msgid "Backdrop blur radius for glass panels in dark mode."
-msgstr ""
+msgstr "ダークモードのグラスパネルの背景ブラー半径。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:92
 msgid ""
 "Backdrop blur radius for glass panels. Higher values create a more frosted "
 "appearance."
-msgstr ""
+msgstr "グラスパネルの背景ブラー半径。大きい値ほどすりガラス風の効果が強くなります。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:120
 msgid "Background"
-msgstr ""
+msgstr "背景"
 
 #: htdocs/luci-static/resources/view/system/glass.js:98
 msgid ""
 "Background opacity of glass panels (0 = fully transparent, 1 = fully opaque)."
-msgstr ""
+msgstr "グラスパネルの背景不透明度（0 = 完全透明、 1 = 完全不透明）。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:114
 msgid ""
 "Background opacity of glass panels in dark mode (0 = fully transparent, 1 = "
 "fully opaque)."
-msgstr ""
+msgstr "ダークモードのグラスパネルの背景不透明度（0 = 完全透明、 1 = 完全不透明）。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:43
 msgid "Base font size"
-msgstr ""
+msgstr "基本フォントサイズ"
 
 #: htdocs/luci-static/resources/view/system/glass.js:91
 #: htdocs/luci-static/resources/view/system/glass.js:107
 msgid "Blur intensity (px)"
-msgstr ""
+msgstr "ブラー強度（px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:25
 msgid ""
 "Configure the appearance of the Glass theme. Changes take effect after "
 "saving and refreshing the page."
-msgstr ""
+msgstr "Glassテーマの外観を設定します。変更は保存してページを更新すると反映されます。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:32
 msgid ""
 "Controls the overall appearance. \"Normal\" follows the system preference."
-msgstr ""
+msgstr "全体的な外観を制御します。「自動」はシステムの設定に従います。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:123
 msgid "Current background"
-msgstr ""
+msgstr "現在の背景"
 
 #: htdocs/luci-static/resources/view/system/glass.js:35
 msgid "Dark"
-msgstr ""
+msgstr "ダーク"
 
 #: htdocs/luci-static/resources/view/system/glass.js:48
 msgid "Extra Large (18px)"
-msgstr ""
+msgstr "特大（18px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:28
 msgid "General"
-msgstr ""
+msgstr "一般"
 
 #: htdocs/luci-static/resources/view/system/glass.js:104
 msgid "Glass Effects — Dark Mode"
-msgstr ""
+msgstr "ガラスエフェクト — ダークモード"
 
 #: htdocs/luci-static/resources/view/system/glass.js:88
 msgid "Glass Effects — Light Mode"
-msgstr ""
+msgstr "ガラスエフェクト — ライトモード"
 
 #: htdocs/luci-static/resources/view/system/glass.js:24
 msgid "Glass Theme"
-msgstr ""
+msgstr "Glassテーマ"
 
 #: root/usr/share/luci/menu.d/luci-theme-glass.json:3
 msgid "Glass Theme Config"
-msgstr ""
+msgstr "Glassテーマ設定"
 
 #: ucode/template/themes/glass/header.ut:204
 msgid "Go to password configuration..."
-msgstr ""
+msgstr "パスワード設定へ..."
 
 #: root/usr/share/rpcd/acl.d/luci-theme-glass.json:3
 msgid "Grant access for luci-theme-glass"
-msgstr ""
+msgstr "luci-theme-glassへのアクセスを許可"
 
 #: htdocs/luci-static/resources/view/system/glass.js:38
 msgid "Header status bar"
-msgstr ""
+msgstr "ヘッダーステータスバー"
 
 #: ucode/template/themes/glass/sysauth.ut:111
 msgid "Invalid username and/or password! Please try again."
-msgstr ""
+msgstr "ユーザー名またはパスワードが間違います。再度お試しください。"
 
 #: ucode/template/themes/glass/header.ut:211
 msgid "JavaScript required!"
-msgstr ""
+msgstr "JavaScriptが必要です！"
 
 #: htdocs/luci-static/resources/view/system/glass.js:47
 msgid "Large (16px)"
-msgstr ""
+msgstr "大（16px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:34
 msgid "Light"
-msgstr ""
+msgstr "ライト"
 
 #: ucode/template/themes/glass/sysauth.ut:129
 msgid "Log in"
-msgstr ""
+msgstr "ログイン"
 
 #: ucode/template/themes/glass/sysauth.ut:51
 msgid "Login"
-msgstr ""
+msgstr "ログイン"
 
 #: htdocs/luci-static/resources/view/system/glass.js:131
 msgid ""
 "No background set. Upload an image or video named \"bg\" (e.g. bg.jpg, "
 "bg.png, bg.mp4) to /www/luci-static/glass/background/ via SCP."
 msgstr ""
+"背景が未設定です。SCPで\"bg\"という名前の画像または動画（bg.jpg、"
+"bg.png、bg.mp4など）を /www/luci-static/glass/background/ にアップロードしてください。"
 
 #: ucode/template/themes/glass/header.ut:201
 msgid "No password set!"
-msgstr ""
+msgstr "パスワードが未設定です！"
 
 #: htdocs/luci-static/resources/view/system/glass.js:46
 msgid "Normal (14px)"
-msgstr ""
+msgstr "標準（14px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:97
 #: htdocs/luci-static/resources/view/system/glass.js:113
 msgid "Panel transparency"
-msgstr ""
+msgstr "パネル透明度"
 
 #: ucode/template/themes/glass/sysauth.ut:124
 msgid "Password"
-msgstr ""
+msgstr "パスワード"
 
 #: htdocs/luci-static/resources/view/system/glass.js:71
 msgid "Primary color (dark mode)"
-msgstr ""
+msgstr "メインカラー（ダークモード）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:55
 msgid "Primary color (light mode)"
-msgstr ""
+msgstr "メインカラー（ライトモード）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:44
 msgid ""
 "Scales all text in the theme. Larger values improve readability on high-DPI "
 "displays."
-msgstr ""
+msgstr "テーマ内のすべてのテキストをスケーリングします。大きい値は高解像度ディスプレイでの読みやすさを向上させます。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:39
 msgid ""
 "Show live system stats (CPU, RAM, network, uptime) in the header. Disable to "
 "reduce resource usage on low-end devices."
-msgstr ""
+msgstr "ヘッダーにリアルタイムのシステム情報（CPU、RAM、ネットワーク、稼働時間）を表示。低スペック端末では無効にできます。"
 
 #: ucode/template/themes/glass/sysauth.ut:106
 msgid "Sign in to continue"
@@ -187,23 +189,23 @@ msgstr "続行するにはサインインしてください"
 
 #: htdocs/luci-static/resources/view/system/glass.js:45
 msgid "Small (13px)"
-msgstr ""
+msgstr "小（13px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:31
 msgid "Theme mode"
-msgstr ""
+msgstr "テーマモード"
 
 #: ucode/template/themes/glass/header.ut:202
 msgid ""
 "There is no password set on this router. Please configure a root password to "
 "protect the web interface."
-msgstr ""
+msgstr "このルーターにパスワードが設定されていません。Webインターフェースを保護するために root パスワードを設定してください。"
 
 #: ucode/template/themes/glass/sysauth.ut:117
 msgid "Username"
-msgstr ""
+msgstr "ユーザー名"
 
 #: ucode/template/themes/glass/header.ut:212
 msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
-msgstr ""
+msgstr "ブラウザーでJavaScriptを有効にしないと、LuCIが正常に動作しません。"

--- a/po/ko/glass.po
+++ b/po/ko/glass.po
@@ -6,180 +6,182 @@ msgstr ""
 
 #: htdocs/luci-static/resources/view/system/glass.js:52
 msgid "Accent Colors"
-msgstr ""
+msgstr "강조 색상"
 
 #: htdocs/luci-static/resources/view/system/glass.js:72
 msgid "Accent color used for active elements, links, and buttons in dark mode."
-msgstr ""
+msgstr "다크 모드에서 활성 요소, 링크, 버튼에 사용되는 강조 색상."
 
 #: htdocs/luci-static/resources/view/system/glass.js:56
 msgid ""
 "Accent color used for active elements, links, and buttons in light mode."
-msgstr ""
+msgstr "라이트 모드에서 활성 요소, 링크, 버튼에 사용되는 강조 색상."
 
 #: htdocs/luci-static/resources/view/system/glass.js:128
 msgid "Active"
-msgstr ""
+msgstr "설정됨"
 
 #: htdocs/luci-static/resources/view/system/glass.js:33
 msgid "Auto (follow system)"
-msgstr ""
+msgstr "자동 (시스템 따르기)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:108
 msgid "Backdrop blur radius for glass panels in dark mode."
-msgstr ""
+msgstr "다크 모드 글래스 패널의 배경 흐림 반경."
 
 #: htdocs/luci-static/resources/view/system/glass.js:92
 msgid ""
 "Backdrop blur radius for glass panels. Higher values create a more frosted "
 "appearance."
-msgstr ""
+msgstr "글래스 패널의 배경 흐림 반경. 값이 클수록 유리 효과가 강해집니다."
 
 #: htdocs/luci-static/resources/view/system/glass.js:120
 msgid "Background"
-msgstr ""
+msgstr "배경"
 
 #: htdocs/luci-static/resources/view/system/glass.js:98
 msgid ""
 "Background opacity of glass panels (0 = fully transparent, 1 = fully opaque)."
-msgstr ""
+msgstr "글래스 패널 배경 불투명도 (0 = 완전 투명, 1 = 완전 불투명)."
 
 #: htdocs/luci-static/resources/view/system/glass.js:114
 msgid ""
 "Background opacity of glass panels in dark mode (0 = fully transparent, 1 = "
 "fully opaque)."
-msgstr ""
+msgstr "다크 모드 글래스 패널 배경 불투명도 (0 = 완전 투명, 1 = 완전 불투명)."
 
 #: htdocs/luci-static/resources/view/system/glass.js:43
 msgid "Base font size"
-msgstr ""
+msgstr "기본 글꼴 크기"
 
 #: htdocs/luci-static/resources/view/system/glass.js:91
 #: htdocs/luci-static/resources/view/system/glass.js:107
 msgid "Blur intensity (px)"
-msgstr ""
+msgstr "흐림 강도 (px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:25
 msgid ""
 "Configure the appearance of the Glass theme. Changes take effect after "
 "saving and refreshing the page."
-msgstr ""
+msgstr "Glass 테마 외관을 설정합니다. 변경 사항은 저장 후 페이지를 새로고침하면 적용됩니다."
 
 #: htdocs/luci-static/resources/view/system/glass.js:32
 msgid ""
 "Controls the overall appearance. \"Normal\" follows the system preference."
-msgstr ""
+msgstr "전체적인 외관을 제어합니다. '자동'은 시스템 환경설정을 따릅니다."
 
 #: htdocs/luci-static/resources/view/system/glass.js:123
 msgid "Current background"
-msgstr ""
+msgstr "현재 배경"
 
 #: htdocs/luci-static/resources/view/system/glass.js:35
 msgid "Dark"
-msgstr ""
+msgstr "다크"
 
 #: htdocs/luci-static/resources/view/system/glass.js:48
 msgid "Extra Large (18px)"
-msgstr ""
+msgstr "특대 (18px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:28
 msgid "General"
-msgstr ""
+msgstr "일반"
 
 #: htdocs/luci-static/resources/view/system/glass.js:104
 msgid "Glass Effects — Dark Mode"
-msgstr ""
+msgstr "유리 효과 — 다크 모드"
 
 #: htdocs/luci-static/resources/view/system/glass.js:88
 msgid "Glass Effects — Light Mode"
-msgstr ""
+msgstr "유리 효과 — 라이트 모드"
 
 #: htdocs/luci-static/resources/view/system/glass.js:24
 msgid "Glass Theme"
-msgstr ""
+msgstr "Glass 테마"
 
 #: root/usr/share/luci/menu.d/luci-theme-glass.json:3
 msgid "Glass Theme Config"
-msgstr ""
+msgstr "Glass 테마 설정"
 
 #: ucode/template/themes/glass/header.ut:204
 msgid "Go to password configuration..."
-msgstr ""
+msgstr "비밀번호 설정으로..."
 
 #: root/usr/share/rpcd/acl.d/luci-theme-glass.json:3
 msgid "Grant access for luci-theme-glass"
-msgstr ""
+msgstr "luci-theme-glass 접근 허용"
 
 #: htdocs/luci-static/resources/view/system/glass.js:38
 msgid "Header status bar"
-msgstr ""
+msgstr "헤더 상태 표시줄"
 
 #: ucode/template/themes/glass/sysauth.ut:111
 msgid "Invalid username and/or password! Please try again."
-msgstr ""
+msgstr "사용자 이름 또는 비밀번호가 잘못되었습니다! 다시 시도하세요."
 
 #: ucode/template/themes/glass/header.ut:211
 msgid "JavaScript required!"
-msgstr ""
+msgstr "JavaScript가 필요합니다!"
 
 #: htdocs/luci-static/resources/view/system/glass.js:47
 msgid "Large (16px)"
-msgstr ""
+msgstr "크게 (16px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:34
 msgid "Light"
-msgstr ""
+msgstr "라이트"
 
 #: ucode/template/themes/glass/sysauth.ut:129
 msgid "Log in"
-msgstr ""
+msgstr "로그인"
 
 #: ucode/template/themes/glass/sysauth.ut:51
 msgid "Login"
-msgstr ""
+msgstr "로그인"
 
 #: htdocs/luci-static/resources/view/system/glass.js:131
 msgid ""
 "No background set. Upload an image or video named \"bg\" (e.g. bg.jpg, "
 "bg.png, bg.mp4) to /www/luci-static/glass/background/ via SCP."
 msgstr ""
+"배경이 설정되지 않았습니다. SCP를 통해 \"bg\" 이름의 이미지나 동영상(bg.jpg, "
+"bg.png, bg.mp4 등)을 /www/luci-static/glass/background/ 에 업로드하세요."
 
 #: ucode/template/themes/glass/header.ut:201
 msgid "No password set!"
-msgstr ""
+msgstr "비밀번호가 설정되지 않았습니다!"
 
 #: htdocs/luci-static/resources/view/system/glass.js:46
 msgid "Normal (14px)"
-msgstr ""
+msgstr "표준 (14px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:97
 #: htdocs/luci-static/resources/view/system/glass.js:113
 msgid "Panel transparency"
-msgstr ""
+msgstr "패널 투명도"
 
 #: ucode/template/themes/glass/sysauth.ut:124
 msgid "Password"
-msgstr ""
+msgstr "비밀번호"
 
 #: htdocs/luci-static/resources/view/system/glass.js:71
 msgid "Primary color (dark mode)"
-msgstr ""
+msgstr "주 색상 (다크 모드)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:55
 msgid "Primary color (light mode)"
-msgstr ""
+msgstr "주 색상 (라이트 모드)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:44
 msgid ""
 "Scales all text in the theme. Larger values improve readability on high-DPI "
 "displays."
-msgstr ""
+msgstr "테마의 모든 텍스트를 확대/축소합니다. 높은 값은 고해상도 디스플레이에서 가독성을 향상시킵니다."
 
 #: htdocs/luci-static/resources/view/system/glass.js:39
 msgid ""
 "Show live system stats (CPU, RAM, network, uptime) in the header. Disable to "
 "reduce resource usage on low-end devices."
-msgstr ""
+msgstr "헤더에 실시간 시스템 정보(CPU, RAM, 네트워크, 가동 시간)를 표시합니다. 저사양 장치에서는 비활성화하세요."
 
 #: ucode/template/themes/glass/sysauth.ut:106
 msgid "Sign in to continue"
@@ -187,23 +189,23 @@ msgstr "계속하려면 로그인하세요"
 
 #: htdocs/luci-static/resources/view/system/glass.js:45
 msgid "Small (13px)"
-msgstr ""
+msgstr "작게 (13px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:31
 msgid "Theme mode"
-msgstr ""
+msgstr "테마 모드"
 
 #: ucode/template/themes/glass/header.ut:202
 msgid ""
 "There is no password set on this router. Please configure a root password to "
 "protect the web interface."
-msgstr ""
+msgstr "이 라우터에 비밀번호가 설정되지 않았습니다. 웹 인터페이스를 보호하려면 root 비밀번호를 설정하세요."
 
 #: ucode/template/themes/glass/sysauth.ut:117
 msgid "Username"
-msgstr ""
+msgstr "사용자 이름"
 
 #: ucode/template/themes/glass/header.ut:212
 msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
-msgstr ""
+msgstr "브라우저에서 JavaScript를 활성화해야 LuCI가 정상적으로 작동합니다."

--- a/po/pt-br/glass.po
+++ b/po/pt-br/glass.po
@@ -6,204 +6,206 @@ msgstr ""
 
 #: htdocs/luci-static/resources/view/system/glass.js:52
 msgid "Accent Colors"
-msgstr ""
+msgstr "Cores de destaque"
 
 #: htdocs/luci-static/resources/view/system/glass.js:72
 msgid "Accent color used for active elements, links, and buttons in dark mode."
-msgstr ""
+msgstr "Cor de destaque para elementos ativos, links e botões no modo escuro."
 
 #: htdocs/luci-static/resources/view/system/glass.js:56
 msgid ""
 "Accent color used for active elements, links, and buttons in light mode."
-msgstr ""
+msgstr "Cor de destaque para elementos ativos, links e botões no modo claro."
 
 #: htdocs/luci-static/resources/view/system/glass.js:128
 msgid "Active"
-msgstr ""
+msgstr "Ativo"
 
 #: htdocs/luci-static/resources/view/system/glass.js:33
 msgid "Auto (follow system)"
-msgstr ""
+msgstr "Automático (seguir sistema)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:108
 msgid "Backdrop blur radius for glass panels in dark mode."
-msgstr ""
+msgstr "Raio de desfoque do plano de fundo dos painéis no modo escuro."
 
 #: htdocs/luci-static/resources/view/system/glass.js:92
 msgid ""
 "Backdrop blur radius for glass panels. Higher values create a more frosted "
 "appearance."
-msgstr ""
+msgstr "Raio de desfoque do plano de fundo dos painéis de vidro. Valores maiores criam um efeito fosco mais intenso."
 
 #: htdocs/luci-static/resources/view/system/glass.js:120
 msgid "Background"
-msgstr ""
+msgstr "Plano de fundo"
 
 #: htdocs/luci-static/resources/view/system/glass.js:98
 msgid ""
 "Background opacity of glass panels (0 = fully transparent, 1 = fully opaque)."
-msgstr ""
+msgstr "Opacidade do plano de fundo dos painéis de vidro (0 = totalmente transparente, 1 = totalmente opaco)."
 
 #: htdocs/luci-static/resources/view/system/glass.js:114
 msgid ""
 "Background opacity of glass panels in dark mode (0 = fully transparent, 1 = "
 "fully opaque)."
-msgstr ""
+msgstr "Opacidade do plano de fundo dos painéis no modo escuro (0 = totalmente transparente, 1 = totalmente opaco)."
 
 #: htdocs/luci-static/resources/view/system/glass.js:43
 msgid "Base font size"
-msgstr ""
+msgstr "Tamanho base da fonte"
 
 #: htdocs/luci-static/resources/view/system/glass.js:91
 #: htdocs/luci-static/resources/view/system/glass.js:107
 msgid "Blur intensity (px)"
-msgstr ""
+msgstr "Intensidade do desfoque (px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:25
 msgid ""
 "Configure the appearance of the Glass theme. Changes take effect after "
 "saving and refreshing the page."
-msgstr ""
+msgstr "Configure a aparência do tema Glass. As alterações entram em vigor após salvar e atualizar a página."
 
 #: htdocs/luci-static/resources/view/system/glass.js:32
 msgid ""
 "Controls the overall appearance. \"Normal\" follows the system preference."
-msgstr ""
+msgstr "Controla a aparência geral. «Automático» segue as preferências do sistema."
 
 #: htdocs/luci-static/resources/view/system/glass.js:123
 msgid "Current background"
-msgstr ""
+msgstr "Plano de fundo atual"
 
 #: htdocs/luci-static/resources/view/system/glass.js:35
 msgid "Dark"
-msgstr ""
+msgstr "Escuro"
 
 #: htdocs/luci-static/resources/view/system/glass.js:48
 msgid "Extra Large (18px)"
-msgstr ""
+msgstr "Extra grande (18px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:28
 msgid "General"
-msgstr ""
+msgstr "Geral"
 
 #: htdocs/luci-static/resources/view/system/glass.js:104
 msgid "Glass Effects — Dark Mode"
-msgstr ""
+msgstr "Efeitos de vidro — Modo escuro"
 
 #: htdocs/luci-static/resources/view/system/glass.js:88
 msgid "Glass Effects — Light Mode"
-msgstr ""
+msgstr "Efeitos de vidro — Modo claro"
 
 #: htdocs/luci-static/resources/view/system/glass.js:24
 msgid "Glass Theme"
-msgstr ""
+msgstr "Tema Glass"
 
 #: root/usr/share/luci/menu.d/luci-theme-glass.json:3
 msgid "Glass Theme Config"
-msgstr ""
+msgstr "Configuração do tema Glass"
 
 #: ucode/template/themes/glass/header.ut:204
 msgid "Go to password configuration..."
-msgstr ""
+msgstr "Ir para configuração de senha..."
 
 #: root/usr/share/rpcd/acl.d/luci-theme-glass.json:3
 msgid "Grant access for luci-theme-glass"
-msgstr ""
+msgstr "Conceder acesso ao luci-theme-glass"
 
 #: htdocs/luci-static/resources/view/system/glass.js:38
 msgid "Header status bar"
-msgstr ""
+msgstr "Barra de status do cabeçalho"
 
 #: ucode/template/themes/glass/sysauth.ut:111
 msgid "Invalid username and/or password! Please try again."
-msgstr ""
+msgstr "Nome de usuário e/ou senha inválidos! Tente novamente."
 
 #: ucode/template/themes/glass/header.ut:211
 msgid "JavaScript required!"
-msgstr ""
+msgstr "JavaScript necessário!"
 
 #: htdocs/luci-static/resources/view/system/glass.js:47
 msgid "Large (16px)"
-msgstr ""
+msgstr "Grande (16px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:34
 msgid "Light"
-msgstr ""
+msgstr "Claro"
 
 #: ucode/template/themes/glass/sysauth.ut:129
 msgid "Log in"
-msgstr ""
+msgstr "Entrar"
 
 #: ucode/template/themes/glass/sysauth.ut:51
 msgid "Login"
-msgstr ""
+msgstr "Login"
 
 #: htdocs/luci-static/resources/view/system/glass.js:131
 msgid ""
 "No background set. Upload an image or video named \"bg\" (e.g. bg.jpg, "
 "bg.png, bg.mp4) to /www/luci-static/glass/background/ via SCP."
 msgstr ""
+"Nenhum plano de fundo definido. Envie uma imagem ou vídeo chamado \"bg\" (ex: bg.jpg, "
+"bg.png, bg.mp4) para /www/luci-static/glass/background/ via SCP."
 
 #: ucode/template/themes/glass/header.ut:201
 msgid "No password set!"
-msgstr ""
+msgstr "Nenhuma senha definida!"
 
 #: htdocs/luci-static/resources/view/system/glass.js:46
 msgid "Normal (14px)"
-msgstr ""
+msgstr "Normal (14px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:97
 #: htdocs/luci-static/resources/view/system/glass.js:113
 msgid "Panel transparency"
-msgstr ""
+msgstr "Transparência do painel"
 
 #: ucode/template/themes/glass/sysauth.ut:124
 msgid "Password"
-msgstr ""
+msgstr "Senha"
 
 #: htdocs/luci-static/resources/view/system/glass.js:71
 msgid "Primary color (dark mode)"
-msgstr ""
+msgstr "Cor primária (modo escuro)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:55
 msgid "Primary color (light mode)"
-msgstr ""
+msgstr "Cor primária (modo claro)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:44
 msgid ""
 "Scales all text in the theme. Larger values improve readability on high-DPI "
 "displays."
-msgstr ""
+msgstr "Redimensiona todo o texto do tema. Valores maiores melhoram a legibilidade em telas de alta resolução."
 
 #: htdocs/luci-static/resources/view/system/glass.js:39
 msgid ""
 "Show live system stats (CPU, RAM, network, uptime) in the header. Disable to "
 "reduce resource usage on low-end devices."
-msgstr ""
+msgstr "Exiba estatísticas do sistema em tempo real (CPU, RAM, rede, uptime) no cabeçalho. Desative para reduzir o uso de recursos em dispositivos de baixo desempenho."
 
 #: ucode/template/themes/glass/sysauth.ut:106
 msgid "Sign in to continue"
-msgstr "Faça login para continuar"
+msgstr "Entre para continuar"
 
 #: htdocs/luci-static/resources/view/system/glass.js:45
 msgid "Small (13px)"
-msgstr ""
+msgstr "Pequeno (13px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:31
 msgid "Theme mode"
-msgstr ""
+msgstr "Modo do tema"
 
 #: ucode/template/themes/glass/header.ut:202
 msgid ""
 "There is no password set on this router. Please configure a root password to "
 "protect the web interface."
-msgstr ""
+msgstr "Não há senha definida neste roteador. Configure uma senha root para proteger a interface web."
 
 #: ucode/template/themes/glass/sysauth.ut:117
 msgid "Username"
-msgstr ""
+msgstr "Nome de usuário"
 
 #: ucode/template/themes/glass/header.ut:212
 msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
-msgstr ""
+msgstr "Você deve habilitar JavaScript no navegador ou o LuCI não funcionará corretamente."

--- a/po/ru/glass.po
+++ b/po/ru/glass.po
@@ -6,180 +6,182 @@ msgstr ""
 
 #: htdocs/luci-static/resources/view/system/glass.js:52
 msgid "Accent Colors"
-msgstr ""
+msgstr "Цвета акцента"
 
 #: htdocs/luci-static/resources/view/system/glass.js:72
 msgid "Accent color used for active elements, links, and buttons in dark mode."
-msgstr ""
+msgstr "Цвет акцента для активных элементов, ссылок и кнопок в тёмном режиме."
 
 #: htdocs/luci-static/resources/view/system/glass.js:56
 msgid ""
 "Accent color used for active elements, links, and buttons in light mode."
-msgstr ""
+msgstr "Цвет акцента для активных элементов, ссылок и кнопок в светлом режиме."
 
 #: htdocs/luci-static/resources/view/system/glass.js:128
 msgid "Active"
-msgstr ""
+msgstr "Установлен"
 
 #: htdocs/luci-static/resources/view/system/glass.js:33
 msgid "Auto (follow system)"
-msgstr ""
+msgstr "Авто (по системе)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:108
 msgid "Backdrop blur radius for glass panels in dark mode."
-msgstr ""
+msgstr "Радиус размытия фона панелей в тёмном режиме."
 
 #: htdocs/luci-static/resources/view/system/glass.js:92
 msgid ""
 "Backdrop blur radius for glass panels. Higher values create a more frosted "
 "appearance."
-msgstr ""
+msgstr "Радиус размытия фона стеклянных панелей. Большие значения дают эффект матового стекла."
 
 #: htdocs/luci-static/resources/view/system/glass.js:120
 msgid "Background"
-msgstr ""
+msgstr "Фон"
 
 #: htdocs/luci-static/resources/view/system/glass.js:98
 msgid ""
 "Background opacity of glass panels (0 = fully transparent, 1 = fully opaque)."
-msgstr ""
+msgstr "Непрозрачность фона стеклянных панелей (0 = полностью прозрачный, 1 = полностью непрозрачный)."
 
 #: htdocs/luci-static/resources/view/system/glass.js:114
 msgid ""
 "Background opacity of glass panels in dark mode (0 = fully transparent, 1 = "
 "fully opaque)."
-msgstr ""
+msgstr "Непрозрачность фона панелей в тёмном режиме (0 = полностью прозрачный, 1 = полностью непрозрачный)."
 
 #: htdocs/luci-static/resources/view/system/glass.js:43
 msgid "Base font size"
-msgstr ""
+msgstr "Базовый размер шрифта"
 
 #: htdocs/luci-static/resources/view/system/glass.js:91
 #: htdocs/luci-static/resources/view/system/glass.js:107
 msgid "Blur intensity (px)"
-msgstr ""
+msgstr "Интенсивность размытия (px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:25
 msgid ""
 "Configure the appearance of the Glass theme. Changes take effect after "
 "saving and refreshing the page."
-msgstr ""
+msgstr "Настройка внешнего вида темы Glass. Изменения вступают в силу после сохранения и обновления страницы."
 
 #: htdocs/luci-static/resources/view/system/glass.js:32
 msgid ""
 "Controls the overall appearance. \"Normal\" follows the system preference."
-msgstr ""
+msgstr "Управляет общим внешним видом. «Авто» следует системным настройкам."
 
 #: htdocs/luci-static/resources/view/system/glass.js:123
 msgid "Current background"
-msgstr ""
+msgstr "Текущий фон"
 
 #: htdocs/luci-static/resources/view/system/glass.js:35
 msgid "Dark"
-msgstr ""
+msgstr "Тёмный"
 
 #: htdocs/luci-static/resources/view/system/glass.js:48
 msgid "Extra Large (18px)"
-msgstr ""
+msgstr "Очень крупный (18px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:28
 msgid "General"
-msgstr ""
+msgstr "Основные"
 
 #: htdocs/luci-static/resources/view/system/glass.js:104
 msgid "Glass Effects — Dark Mode"
-msgstr ""
+msgstr "Эффекты стекла — тёмный режим"
 
 #: htdocs/luci-static/resources/view/system/glass.js:88
 msgid "Glass Effects — Light Mode"
-msgstr ""
+msgstr "Эффекты стекла — светлый режим"
 
 #: htdocs/luci-static/resources/view/system/glass.js:24
 msgid "Glass Theme"
-msgstr ""
+msgstr "Тема Glass"
 
 #: root/usr/share/luci/menu.d/luci-theme-glass.json:3
 msgid "Glass Theme Config"
-msgstr ""
+msgstr "Настройка темы Glass"
 
 #: ucode/template/themes/glass/header.ut:204
 msgid "Go to password configuration..."
-msgstr ""
+msgstr "Перейти к настройке пароля..."
 
 #: root/usr/share/rpcd/acl.d/luci-theme-glass.json:3
 msgid "Grant access for luci-theme-glass"
-msgstr ""
+msgstr "Предоставить доступ для luci-theme-glass"
 
 #: htdocs/luci-static/resources/view/system/glass.js:38
 msgid "Header status bar"
-msgstr ""
+msgstr "Строка состояния в заголовке"
 
 #: ucode/template/themes/glass/sysauth.ut:111
 msgid "Invalid username and/or password! Please try again."
-msgstr ""
+msgstr "Неверное имя пользователя или пароль! Попробуйте снова."
 
 #: ucode/template/themes/glass/header.ut:211
 msgid "JavaScript required!"
-msgstr ""
+msgstr "Требуется JavaScript!"
 
 #: htdocs/luci-static/resources/view/system/glass.js:47
 msgid "Large (16px)"
-msgstr ""
+msgstr "Крупный (16px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:34
 msgid "Light"
-msgstr ""
+msgstr "Светлый"
 
 #: ucode/template/themes/glass/sysauth.ut:129
 msgid "Log in"
-msgstr ""
+msgstr "Войти"
 
 #: ucode/template/themes/glass/sysauth.ut:51
 msgid "Login"
-msgstr ""
+msgstr "Вход"
 
 #: htdocs/luci-static/resources/view/system/glass.js:131
 msgid ""
 "No background set. Upload an image or video named \"bg\" (e.g. bg.jpg, "
 "bg.png, bg.mp4) to /www/luci-static/glass/background/ via SCP."
 msgstr ""
+"Фон не установлен. Загрузите изображение или видео с именем \"bg\" (например, bg.jpg, "
+"bg.png, bg.mp4) в /www/luci-static/glass/background/ через SCP."
 
 #: ucode/template/themes/glass/header.ut:201
 msgid "No password set!"
-msgstr ""
+msgstr "Пароль не установлен!"
 
 #: htdocs/luci-static/resources/view/system/glass.js:46
 msgid "Normal (14px)"
-msgstr ""
+msgstr "Обычный (14px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:97
 #: htdocs/luci-static/resources/view/system/glass.js:113
 msgid "Panel transparency"
-msgstr ""
+msgstr "Прозрачность панелей"
 
 #: ucode/template/themes/glass/sysauth.ut:124
 msgid "Password"
-msgstr ""
+msgstr "Пароль"
 
 #: htdocs/luci-static/resources/view/system/glass.js:71
 msgid "Primary color (dark mode)"
-msgstr ""
+msgstr "Основной цвет (тёмный режим)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:55
 msgid "Primary color (light mode)"
-msgstr ""
+msgstr "Основной цвет (светлый режим)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:44
 msgid ""
 "Scales all text in the theme. Larger values improve readability on high-DPI "
 "displays."
-msgstr ""
+msgstr "Масштабирует весь текст темы. Большие значения улучшают читаемость на дисплеях с высоким DPI."
 
 #: htdocs/luci-static/resources/view/system/glass.js:39
 msgid ""
 "Show live system stats (CPU, RAM, network, uptime) in the header. Disable to "
 "reduce resource usage on low-end devices."
-msgstr ""
+msgstr "Показывать статистику системы (CPU, ОЗУ, сеть, время работы) в заголовке. Отключите на слабых устройствах."
 
 #: ucode/template/themes/glass/sysauth.ut:106
 msgid "Sign in to continue"
@@ -187,23 +189,23 @@ msgstr "Войдите для продолжения"
 
 #: htdocs/luci-static/resources/view/system/glass.js:45
 msgid "Small (13px)"
-msgstr ""
+msgstr "Мелкий (13px)"
 
 #: htdocs/luci-static/resources/view/system/glass.js:31
 msgid "Theme mode"
-msgstr ""
+msgstr "Режим темы"
 
 #: ucode/template/themes/glass/header.ut:202
 msgid ""
 "There is no password set on this router. Please configure a root password to "
 "protect the web interface."
-msgstr ""
+msgstr "На этом роутере не установлен пароль. Пожалуйста, задайте пароль root для защиты веб-интерфейса."
 
 #: ucode/template/themes/glass/sysauth.ut:117
 msgid "Username"
-msgstr ""
+msgstr "Имя пользователя"
 
 #: ucode/template/themes/glass/header.ut:212
 msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
-msgstr ""
+msgstr "Необходимо включить JavaScript в браузере, иначе LuCI не будет работать корректно."

--- a/po/zh_Hans/glass.po
+++ b/po/zh_Hans/glass.po
@@ -6,180 +6,182 @@ msgstr ""
 
 #: htdocs/luci-static/resources/view/system/glass.js:52
 msgid "Accent Colors"
-msgstr ""
+msgstr "强调色"
 
 #: htdocs/luci-static/resources/view/system/glass.js:72
 msgid "Accent color used for active elements, links, and buttons in dark mode."
-msgstr ""
+msgstr "深色模式下用于活动元素、链接和按钮的强调色。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:56
 msgid ""
 "Accent color used for active elements, links, and buttons in light mode."
-msgstr ""
+msgstr "浅色模式下用于活动元素、链接和按钮的强调色。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:128
 msgid "Active"
-msgstr ""
+msgstr "已设置"
 
 #: htdocs/luci-static/resources/view/system/glass.js:33
 msgid "Auto (follow system)"
-msgstr ""
+msgstr "自动（跟随系统）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:108
 msgid "Backdrop blur radius for glass panels in dark mode."
-msgstr ""
+msgstr "深色模式下玻璃面板的背景模糊半径。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:92
 msgid ""
 "Backdrop blur radius for glass panels. Higher values create a more frosted "
 "appearance."
-msgstr ""
+msgstr "玻璃面板的背景模糊半径，数值越大磨砂效果越强。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:120
 msgid "Background"
-msgstr ""
+msgstr "背景"
 
 #: htdocs/luci-static/resources/view/system/glass.js:98
 msgid ""
 "Background opacity of glass panels (0 = fully transparent, 1 = fully opaque)."
-msgstr ""
+msgstr "玻璃面板背景不透明度（0 = 完全透明，1 = 完全不透明）。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:114
 msgid ""
 "Background opacity of glass panels in dark mode (0 = fully transparent, 1 = "
 "fully opaque)."
-msgstr ""
+msgstr "深色模式下玻璃面板背景不透明度（0 = 完全透明，1 = 完全不透明）。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:43
 msgid "Base font size"
-msgstr ""
+msgstr "基础字体大小"
 
 #: htdocs/luci-static/resources/view/system/glass.js:91
 #: htdocs/luci-static/resources/view/system/glass.js:107
 msgid "Blur intensity (px)"
-msgstr ""
+msgstr "模糊强度（px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:25
 msgid ""
 "Configure the appearance of the Glass theme. Changes take effect after "
 "saving and refreshing the page."
-msgstr ""
+msgstr "配置 Glass 主题外观，保存后刷新页面生效。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:32
 msgid ""
 "Controls the overall appearance. \"Normal\" follows the system preference."
-msgstr ""
+msgstr "控制整体外观。"自动"模式跟随系统深浅色偏好。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:123
 msgid "Current background"
-msgstr ""
+msgstr "当前背景"
 
 #: htdocs/luci-static/resources/view/system/glass.js:35
 msgid "Dark"
-msgstr ""
+msgstr "深色"
 
 #: htdocs/luci-static/resources/view/system/glass.js:48
 msgid "Extra Large (18px)"
-msgstr ""
+msgstr "超大（18px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:28
 msgid "General"
-msgstr ""
+msgstr "常规"
 
 #: htdocs/luci-static/resources/view/system/glass.js:104
 msgid "Glass Effects — Dark Mode"
-msgstr ""
+msgstr "玻璃效果 — 深色模式"
 
 #: htdocs/luci-static/resources/view/system/glass.js:88
 msgid "Glass Effects — Light Mode"
-msgstr ""
+msgstr "玻璃效果 — 浅色模式"
 
 #: htdocs/luci-static/resources/view/system/glass.js:24
 msgid "Glass Theme"
-msgstr ""
+msgstr "Glass 主题"
 
 #: root/usr/share/luci/menu.d/luci-theme-glass.json:3
 msgid "Glass Theme Config"
-msgstr ""
+msgstr "Glass 主题配置"
 
 #: ucode/template/themes/glass/header.ut:204
 msgid "Go to password configuration..."
-msgstr ""
+msgstr "前往密码配置..."
 
 #: root/usr/share/rpcd/acl.d/luci-theme-glass.json:3
 msgid "Grant access for luci-theme-glass"
-msgstr ""
+msgstr "授予 luci-theme-glass 访问权限"
 
 #: htdocs/luci-static/resources/view/system/glass.js:38
 msgid "Header status bar"
-msgstr ""
+msgstr "顶栏状态条"
 
 #: ucode/template/themes/glass/sysauth.ut:111
 msgid "Invalid username and/or password! Please try again."
-msgstr ""
+msgstr "用户名或密码错误，请重试。"
 
 #: ucode/template/themes/glass/header.ut:211
 msgid "JavaScript required!"
-msgstr ""
+msgstr "需要启用 JavaScript！"
 
 #: htdocs/luci-static/resources/view/system/glass.js:47
 msgid "Large (16px)"
-msgstr ""
+msgstr "大（16px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:34
 msgid "Light"
-msgstr ""
+msgstr "浅色"
 
 #: ucode/template/themes/glass/sysauth.ut:129
 msgid "Log in"
-msgstr ""
+msgstr "登录"
 
 #: ucode/template/themes/glass/sysauth.ut:51
 msgid "Login"
-msgstr ""
+msgstr "登录"
 
 #: htdocs/luci-static/resources/view/system/glass.js:131
 msgid ""
 "No background set. Upload an image or video named \"bg\" (e.g. bg.jpg, "
 "bg.png, bg.mp4) to /www/luci-static/glass/background/ via SCP."
 msgstr ""
+"未设置背景。请通过 SCP 将名为 \"bg\" 的图片或视频（如 bg.jpg、bg.png、"
+"bg.mp4）上传至 /www/luci-static/glass/background/。"
 
 #: ucode/template/themes/glass/header.ut:201
 msgid "No password set!"
-msgstr ""
+msgstr "未设置密码！"
 
 #: htdocs/luci-static/resources/view/system/glass.js:46
 msgid "Normal (14px)"
-msgstr ""
+msgstr "标准（14px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:97
 #: htdocs/luci-static/resources/view/system/glass.js:113
 msgid "Panel transparency"
-msgstr ""
+msgstr "面板透明度"
 
 #: ucode/template/themes/glass/sysauth.ut:124
 msgid "Password"
-msgstr ""
+msgstr "密码"
 
 #: htdocs/luci-static/resources/view/system/glass.js:71
 msgid "Primary color (dark mode)"
-msgstr ""
+msgstr "主色调（深色模式）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:55
 msgid "Primary color (light mode)"
-msgstr ""
+msgstr "主色调（浅色模式）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:44
 msgid ""
 "Scales all text in the theme. Larger values improve readability on high-DPI "
 "displays."
-msgstr ""
+msgstr "缩放主题内所有文字，较大值可提升高分辨率屏幕的可读性。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:39
 msgid ""
 "Show live system stats (CPU, RAM, network, uptime) in the header. Disable to "
 "reduce resource usage on low-end devices."
-msgstr ""
+msgstr "在顶栏显示实时系统状态（CPU、内存、网络、运行时间），低性能设备可关闭以降低资源占用。"
 
 #: ucode/template/themes/glass/sysauth.ut:106
 msgid "Sign in to continue"
@@ -187,23 +189,23 @@ msgstr "登录以继续"
 
 #: htdocs/luci-static/resources/view/system/glass.js:45
 msgid "Small (13px)"
-msgstr ""
+msgstr "小（13px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:31
 msgid "Theme mode"
-msgstr ""
+msgstr "主题模式"
 
 #: ucode/template/themes/glass/header.ut:202
 msgid ""
 "There is no password set on this router. Please configure a root password to "
 "protect the web interface."
-msgstr ""
+msgstr "此路由器未设置密码，请配置 root 密码以保护 Web 界面。"
 
 #: ucode/template/themes/glass/sysauth.ut:117
 msgid "Username"
-msgstr ""
+msgstr "用户名"
 
 #: ucode/template/themes/glass/header.ut:212
 msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
-msgstr ""
+msgstr "请在浏览器中启用 JavaScript，否则 LuCI 无法正常工作。"

--- a/po/zh_Hant/glass.po
+++ b/po/zh_Hant/glass.po
@@ -6,180 +6,182 @@ msgstr ""
 
 #: htdocs/luci-static/resources/view/system/glass.js:52
 msgid "Accent Colors"
-msgstr ""
+msgstr "強調色彩"
 
 #: htdocs/luci-static/resources/view/system/glass.js:72
 msgid "Accent color used for active elements, links, and buttons in dark mode."
-msgstr ""
+msgstr "深色模式下，用於主動元素、連結和按鈕的強調色彩。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:56
 msgid ""
 "Accent color used for active elements, links, and buttons in light mode."
-msgstr ""
+msgstr "深色模式下，用於主動元素、連結和按鈕的強調色彩。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:128
 msgid "Active"
-msgstr ""
+msgstr "已設定"
 
 #: htdocs/luci-static/resources/view/system/glass.js:33
 msgid "Auto (follow system)"
-msgstr ""
+msgstr "自動（跟隨系統）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:108
 msgid "Backdrop blur radius for glass panels in dark mode."
-msgstr ""
+msgstr "深色模式下玻璊面板的背景模糊半徑。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:92
 msgid ""
 "Backdrop blur radius for glass panels. Higher values create a more frosted "
 "appearance."
-msgstr ""
+msgstr "玻璊面板的背景模糊半徑，數値越大山爿玻璊效果越明顯。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:120
 msgid "Background"
-msgstr ""
+msgstr "背景"
 
 #: htdocs/luci-static/resources/view/system/glass.js:98
 msgid ""
 "Background opacity of glass panels (0 = fully transparent, 1 = fully opaque)."
-msgstr ""
+msgstr "玻璊面板背景不透明度（0 = 完全透明，1 = 完全不透明）。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:114
 msgid ""
 "Background opacity of glass panels in dark mode (0 = fully transparent, 1 = "
 "fully opaque)."
-msgstr ""
+msgstr "深色模式下玻璊面板背景不透明度（0 = 完全透明，1 = 完全不透明）。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:43
 msgid "Base font size"
-msgstr ""
+msgstr "基礎字型大小"
 
 #: htdocs/luci-static/resources/view/system/glass.js:91
 #: htdocs/luci-static/resources/view/system/glass.js:107
 msgid "Blur intensity (px)"
-msgstr ""
+msgstr "模糊強度（px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:25
 msgid ""
 "Configure the appearance of the Glass theme. Changes take effect after "
 "saving and refreshing the page."
-msgstr ""
+msgstr "設定 Glass 主題外觀，儲存後重新整理頁面即可生效。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:32
 msgid ""
 "Controls the overall appearance. \"Normal\" follows the system preference."
-msgstr ""
+msgstr "控制整體外觀。「自動」模式跟隨系統外觀偏好。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:123
 msgid "Current background"
-msgstr ""
+msgstr "目前背景"
 
 #: htdocs/luci-static/resources/view/system/glass.js:35
 msgid "Dark"
-msgstr ""
+msgstr "深色"
 
 #: htdocs/luci-static/resources/view/system/glass.js:48
 msgid "Extra Large (18px)"
-msgstr ""
+msgstr "特大（18px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:28
 msgid "General"
-msgstr ""
+msgstr "一般"
 
 #: htdocs/luci-static/resources/view/system/glass.js:104
 msgid "Glass Effects — Dark Mode"
-msgstr ""
+msgstr "玻璊效果 — 深色模式"
 
 #: htdocs/luci-static/resources/view/system/glass.js:88
 msgid "Glass Effects — Light Mode"
-msgstr ""
+msgstr "玻璊效果 — 淡色模式"
 
 #: htdocs/luci-static/resources/view/system/glass.js:24
 msgid "Glass Theme"
-msgstr ""
+msgstr "Glass 主題"
 
 #: root/usr/share/luci/menu.d/luci-theme-glass.json:3
 msgid "Glass Theme Config"
-msgstr ""
+msgstr "Glass 主題設定"
 
 #: ucode/template/themes/glass/header.ut:204
 msgid "Go to password configuration..."
-msgstr ""
+msgstr "前往密碼設定..."
 
 #: root/usr/share/rpcd/acl.d/luci-theme-glass.json:3
 msgid "Grant access for luci-theme-glass"
-msgstr ""
+msgstr "授予 luci-theme-glass 存取權限"
 
 #: htdocs/luci-static/resources/view/system/glass.js:38
 msgid "Header status bar"
-msgstr ""
+msgstr "頂欄狀態列"
 
 #: ucode/template/themes/glass/sysauth.ut:111
 msgid "Invalid username and/or password! Please try again."
-msgstr ""
+msgstr "使用者名稱或密碼错誤！請重試。"
 
 #: ucode/template/themes/glass/header.ut:211
 msgid "JavaScript required!"
-msgstr ""
+msgstr "需要啟用 JavaScript！"
 
 #: htdocs/luci-static/resources/view/system/glass.js:47
 msgid "Large (16px)"
-msgstr ""
+msgstr "大（16px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:34
 msgid "Light"
-msgstr ""
+msgstr "淡色"
 
 #: ucode/template/themes/glass/sysauth.ut:129
 msgid "Log in"
-msgstr ""
+msgstr "登入"
 
 #: ucode/template/themes/glass/sysauth.ut:51
 msgid "Login"
-msgstr ""
+msgstr "登入"
 
 #: htdocs/luci-static/resources/view/system/glass.js:131
 msgid ""
 "No background set. Upload an image or video named \"bg\" (e.g. bg.jpg, "
 "bg.png, bg.mp4) to /www/luci-static/glass/background/ via SCP."
 msgstr ""
+"未設定背景。請透過 SCP 將名為 \"bg\" 的圖片或影片（bg.jpg、"
+"bg.png、bg.mp4 等）上傳至 /www/luci-static/glass/background/。"
 
 #: ucode/template/themes/glass/header.ut:201
 msgid "No password set!"
-msgstr ""
+msgstr "未設定密碼！"
 
 #: htdocs/luci-static/resources/view/system/glass.js:46
 msgid "Normal (14px)"
-msgstr ""
+msgstr "標準（14px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:97
 #: htdocs/luci-static/resources/view/system/glass.js:113
 msgid "Panel transparency"
-msgstr ""
+msgstr "面板透明度"
 
 #: ucode/template/themes/glass/sysauth.ut:124
 msgid "Password"
-msgstr ""
+msgstr "密碼"
 
 #: htdocs/luci-static/resources/view/system/glass.js:71
 msgid "Primary color (dark mode)"
-msgstr ""
+msgstr "主色調（深色模式）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:55
 msgid "Primary color (light mode)"
-msgstr ""
+msgstr "主色調（淡色模式）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:44
 msgid ""
 "Scales all text in the theme. Larger values improve readability on high-DPI "
 "displays."
-msgstr ""
+msgstr "縮放主題內所有文字，較大數値可提升高長度螢幕上的可讀性。"
 
 #: htdocs/luci-static/resources/view/system/glass.js:39
 msgid ""
 "Show live system stats (CPU, RAM, network, uptime) in the header. Disable to "
 "reduce resource usage on low-end devices."
-msgstr ""
+msgstr "在頂欄顯示即時系統狀態（CPU、記憶體、網路、運行時間）。低記憶體設備可停用以減少資源使用。"
 
 #: ucode/template/themes/glass/sysauth.ut:106
 msgid "Sign in to continue"
@@ -187,23 +189,23 @@ msgstr "登入以繼續"
 
 #: htdocs/luci-static/resources/view/system/glass.js:45
 msgid "Small (13px)"
-msgstr ""
+msgstr "小（13px）"
 
 #: htdocs/luci-static/resources/view/system/glass.js:31
 msgid "Theme mode"
-msgstr ""
+msgstr "主題模式"
 
 #: ucode/template/themes/glass/header.ut:202
 msgid ""
 "There is no password set on this router. Please configure a root password to "
 "protect the web interface."
-msgstr ""
+msgstr "此路由器尚未設定密碼。請設定 root 密碼以保護網頁介面。"
 
 #: ucode/template/themes/glass/sysauth.ut:117
 msgid "Username"
-msgstr ""
+msgstr "使用者名稱"
 
 #: ucode/template/themes/glass/header.ut:212
 msgid ""
 "You must enable JavaScript in your browser or LuCI will not work properly."
-msgstr ""
+msgstr "必須在瀏覽器中啟用 JavaScript，否則 LuCI 無法正常運作。"

--- a/root/usr/share/rpcd/acl.d/luci-theme-glass.json
+++ b/root/usr/share/rpcd/acl.d/luci-theme-glass.json
@@ -7,6 +7,7 @@
                 "/www/luci-static/glass/background/*": [ "list" ]
             },
             "ubus": {
+                "session": [ "access", "login" ],
                 "network.interface": [ "dump" ],
                 "network.device": [ "status" ]
             }


### PR DESCRIPTION
## Summary

Fill all empty `msgstr` entries across 8 language PO files. Previously most languages had only 1-2 translated strings; this PR completes all 38+ entries for each language.

### Languages completed
| Language | Code | Status |
|----------|------|--------|
| German | `de` | ✅ Completed |
| French | `fr` | ✅ Completed |
| Japanese | `ja` | ✅ Completed |
| Korean | `ko` | ✅ Completed |
| Portuguese (Brazil) | `pt-br` | ✅ Completed |
| Russian | `ru` | ✅ Completed |
| Simplified Chinese | `zh_Hans` | ✅ Completed |
| Traditional Chinese | `zh_Hant` | ✅ Completed |

> Note: Spanish (`es`) was already complete and not modified.

### Other changes
- **Makefile**: add `LUCI_DESCRIPTION`, `LUCI_PKGARCH:=all`, rename `CONFIG_LUCI_CSSTIDY` → `LUCI_MINIFY_CSS:=0` (correct variable name per luci.mk)
- **acl.d/luci-theme-glass.json**: add `"session": ["access", "login"]` under `read.ubus` to prevent HTTP 403 on login page